### PR TITLE
build: add zscaler certificates in dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ _site
 .jekyll-metadata
 vendor
 .DS_Store
+.dockerdev/certificates/*
+!.dockerdev/certificates/.keep

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,14 @@
 FROM ruby:3.1
 
+# Copy zscaler certificates to container
+COPY .dockerdev/certificates /certificates
+
+# Update trusted certificates if any exist
+RUN if [ -d /certificates ] && [ "$(ls -A /certificates/*.crt 2>/dev/null)" ]; then \
+  cp /certificates/*.crt /usr/local/share/ca-certificates/ && \
+  update-ca-certificates; \
+fi
+
 # Install dependencies
 RUN apt-get update && apt-get install -y \
     build-essential \

--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ docker-compose up
 ```
 
 Open [http://localhost:4000/culture/](http://localhost:4000/culture/) with your browser to see the project.
+
+### Troubleshooting
+
+#### Docker errors
+
+🐛 **Zscaler problems**
+
+If you have some certificate problem, like this:
+
+```bash
+SSL verification error at depth 2: unable to get local issuer certificate (20)
+```
+
+This error usually occurs because the zscaler certificate is missing. To fix it, get the zscaler `.crt` with your leader, and add it to the `.dockerdev/certificates/` path.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,6 @@ services:
       - PAGES_REPO_NWO=skore-io/culture
       - JEKYLL_ENV=production
       - JEKYLL_FORCE_POLLING=true
+      - SSL_CERT_DIR=/etc/ssl/certs
+      - SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
     command: bundle exec jekyll serve --host 0.0.0.0 --watch


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e905ee64-af11-4720-9e26-6d7bdb88d842)

### What?

Implementando a mesma solução feita em QR para resolver problemas com zscaler ao rodar docker.
Se a pessoa tiver problemas com o zscaler, basta adicionar o arquivo na pasta `.dockerdev/certificates`;
Se a pessoa não tiver problemas com o docker zscaler, não precisa fazer nada.

O certificado pode ser obtido em https://help.zscaler.com/zia/adding-custom-certificate-application-specific-trust-store ou com alguma liderança de engenharia.

### Why?

Muitos problemas ao rodar docker com zscaler habilitado.
